### PR TITLE
Fix: Resolve Android runtime error "Unable to add a view into a view …

### DIFF
--- a/android/src/main/java/com/alentoma/selectabletext/RNSelectableTextManager.java
+++ b/android/src/main/java/com/alentoma/selectabletext/RNSelectableTextManager.java
@@ -33,22 +33,24 @@ public class RNSelectableTextManager extends ReactTextViewManager {
     }
 
     @Override
-    public ReactTextView createViewInstance(ThemedReactContext context) {
-        return new ReactTextView(context);
+    public SelectableTextWrapperView createViewInstance(ThemedReactContext context) {
+        return new SelectableTextWrapperView(context);
     }
 
 
     @ReactProp(name = "menuItems")
-    public void setMenuItems(ReactTextView textView, ReadableArray items) {
+    public void setMenuItems(SelectableTextWrapperView wrapperView, ReadableArray items) {
+        ReactTextView textView = wrapperView.getTextView();
         List<String> result = new ArrayList<String>(items.size());
         for (int i = 0; i < items.size(); i++) {
             result.add(items.getString(i));
         }
 
-        registerSelectionListener(result.toArray(new String[items.size()]), textView);
+        registerSelectionListener(result.toArray(new String[items.size()]), wrapperView);
     }
 
-    public void registerSelectionListener(final String[] menuItems, final ReactTextView view) {
+    public void registerSelectionListener(final String[] menuItems, final SelectableTextWrapperView wrapperView) {
+        final ReactTextView view = wrapperView.getTextView();
         view.setCustomSelectionActionModeCallback(new Callback() {
             @Override
             public boolean onPrepareActionMode(ActionMode mode, Menu menu) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@alexcheuk/react-native-selectable-text",
+    "name": "@rob117/react-native-selectable-text",
     "version": "1.10.0",
     "description": "React Native component used to provide the features of pass different context menu items and events",
     "main": "index.ts",


### PR DESCRIPTION
…that is not a ViewGroup"

The `RNSelectableTextManager` was previously creating a `ReactTextView` directly as the component's root view. `ReactTextView` is not a `ViewGroup` and cannot have children added to it, leading to a runtime crash if React Native attempted to add any child views (e.g., for layout purposes or if the component was used with children in JS).

This commit modifies `RNSelectableTextManager.java` to:
1. Return a `SelectableTextWrapperView` (which extends `FrameLayout`, a `ViewGroup`) from `createViewInstance`. This makes the component's root view a proper `ViewGroup`.
2. Adjust internal methods like `setMenuItems` and `registerSelectionListener` to correctly access the underlying `ReactTextView` instance (now nested within `SelectableTextWrapperView`) via its `getTextView()` method.
3. Ensure that event dispatching (`onSelectNativeEvent`) continues to use the context and ID of the inner `ReactTextView` for correct event propagation to JavaScript.

This change ensures the native view hierarchy is correct, preventing the runtime error and allowing the component to function as expected within Android layouts.